### PR TITLE
Fix windows media player error message

### DIFF
--- a/Source/GaGa/NotifyIconPlayer/Player.cs
+++ b/Source/GaGa/NotifyIconPlayer/Player.cs
@@ -359,8 +359,8 @@ namespace GaGa.NotifyIconPlayer
         {
             Stop();
 
-            String title = "Unable to play: " + Source.Name;
-            String text = e.ErrorException.Message + "\n" + Source.Uri;
+            String title = "Unable to play";
+            String text = e.ErrorException.Message;
 
             notifyIcon.ShowBalloonTip(10, title, text, ToolTipIcon.Error);
         }


### PR DESCRIPTION
The pre-compiled binaries instantly crashed on my minimal windows 10 install.

After trying to compile the source myself i ran into this issue. After installing windows media player via "turn on windows features" the software works perfectly!